### PR TITLE
Make the template work with natbib and apalike

### DIFF
--- a/preamble.tex
+++ b/preamble.tex
@@ -84,7 +84,6 @@
 %\usepackage{longtable}
 %\usepackage{tabularx}
 \usepackage{bibentry}
-\bibliographystyle{plainnat}
 \nobibliography*
 % *********************************** SI Units *********************************
 \usepackage{siunitx} % use this package module for SI units

--- a/thesis.tex
+++ b/thesis.tex
@@ -164,14 +164,6 @@
 \bibliography{References/references} % Path to your References.bib file
 
 
-% If you would like to use BibLaTeX for your references, pass `custombib' as
-% an option in the document class. The location of 'reference.bib' should be
-% specified in the preamble.tex file in the custombib section.
-% Comment out the lines related to natbib above and uncomment the following line.
-
-\printbibliography[heading=bibintoc, title={References}]
-
-
 \end{spacing}
 
 % ********************************** Appendices ********************************


### PR DESCRIPTION
These changes should allow you to get an `apalike` bibliography with `natbib`. 

Specifically,
- `\printbibliography` is a `biblatex` command, but the rest of your document uses `natbib` (which is incompatible with `biblatex`);
- there can only be one `\bibliographystyle` in your document, and you want `\bibliography{apalike}`.

For https://tex.stackexchange.com/q/478788/35864